### PR TITLE
FIX: set codeql scan type as per template project

### DIFF
--- a/.github/workflows/security_codeql_actions_scan.yml
+++ b/.github/workflows/security_codeql_actions_scan.yml
@@ -15,4 +15,5 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql_actions.yml@v2 # WORKFLOW_VERSION
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
+      languages: javascript-typescript
     secrets: inherit


### PR DESCRIPTION
As per https://github.com/ministryofjustice/hmpps-template-typescript/pull/742